### PR TITLE
Shellcheck

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,14 @@
+name: ShellCheck
+
+on: [push]
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run ShellCheck
+      uses: ludeeus/action-shellcheck@master
+      with:
+        severity: warning

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -11,4 +11,4 @@ jobs:
     - name: Run ShellCheck
       uses: ludeeus/action-shellcheck@master
       with:
-        severity: warning
+        severity: error

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -11,4 +11,4 @@ jobs:
     - name: Run ShellCheck
       uses: ludeeus/action-shellcheck@master
       with:
-        severity: error
+        severity: warning

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -184,10 +184,10 @@ doUninstallTools() {
     read -p "Are you sure you want to uninstall the ARK Server Tools? [y/N]" -n 1 -r
 
     if [[ "$REPLY" =~ ^[Yy]$ ]]; then
-      if [ -n "${install_datadir}" -a -x "${install_datadir}/arkmanager-uninstall.sh" ]; then
+      if [ -n "${install_datadir}" ] && [ -x "${install_datadir}/arkmanager-uninstall.sh" ]; then
         $sudo "${install_datadir}/arkmanager-uninstall.sh"
         exit 0
-      elif [ -n "${install_libexecdir}" -a -x "${install_libexecdir}/arkmanager-uninstall.sh" ]; then
+      elif [ -n "${install_libexecdir}" ] && [ -x "${install_libexecdir}/arkmanager-uninstall.sh" ]; then
         $sudo "${install_libexecdir}/arkmanager-uninstall.sh"
         exit 0
       fi
@@ -366,7 +366,7 @@ checkConfig() {
 
     if [ "$1" != "installmod" ] && [ "$1" != "installmods" ]; then
       # Warn if any mods are requested but not installed
-      if [ -n "$arkserverroot" -a -d "${arkserverroot}/${arkserverdir:-ShooterGame}/Content/Mods" ]; then
+      if [ -n "$arkserverroot" ] && [ -d "${arkserverroot}/${arkserverdir:-ShooterGame}/Content/Mods" ]; then
         for modid in $(getModIds); do
           if [ ! -f "${arkserverroot}/${arkserverdir:-ShooterGame}/Content/Mods/${modid}/mod.info" ]; then
             echo -e "[" "$RED" "ERROR" "$NORMAL" "]" "\tMod ${modid} is requested but not installed.  Run 'arkmanager installmod ${modid}' to install this mod." >&2
@@ -377,7 +377,7 @@ checkConfig() {
   fi
 
   # Warn if mod_branch=Linux
-  if [ "$mod_branch" == "Linux" -a -z "$nowarnmodbranch" ]; then
+  if [ "$mod_branch" == "Linux" ] && [ -z "$nowarnmodbranch" ]; then
     echo -e "[" "$YELLOW" "WARN" "$NORMAL" "]" "\tmod_branch is set to Linux. Linux mods are known to cause the server to crash. It is suggested you set mod_branch to Windows." >&2
   fi
 
@@ -776,7 +776,7 @@ function parseSteamACF(){
     elif [ "$name" == "{" ]; then
       parseSteamACF "$1" "$2" "${3}.${sname}"
     else
-      if [ "$3" == "$1" -a "$name" == "$2" ]; then
+      if [ "$3" == "$1" ] && [ "$name" == "$2" ]; then
         echo "$val"
         break
       fi
@@ -2006,7 +2006,7 @@ doUpdate() {
   if [ -n "$appupdate" ] || isUpdateNeeded; then
     appupdate=1
 
-    if [ -n "${arkStagingDir}" -a "${arkStagingDir}" != "${arkserverroot}" ]; then
+    if [ -n "${arkStagingDir}" ] && [ "${arkStagingDir}" != "${arkserverroot}" ]; then
       if [ ! -d "$arkStagingDir/${arkserverdir}" ]; then
         logprint "Copying to staging directory"
         mkdir -p "$arkStagingDir"
@@ -2079,14 +2079,14 @@ doUpdate() {
   fi
 
   if [ -n "$downloadonly" ]; then
-    if [ -n "$appupdate" -a -n "$arkStagingDir" -a "$arkStagingDir" != "$arkserverroot" ]; then
+    if [ -n "$appupdate" ] && [ -n "$arkStagingDir" ] && [ "$arkStagingDir" != "$arkserverroot" ]; then
       logprint "Server update downloaded"
     fi
     if [ -n "$modupdate" ]; then
       logprint "Mod update downloaded"
     fi
     logprint "Not applying update - download-only requested"
-  elif [ -n "$appupdate" -o -n "$modupdate" -o -n "$bgupdate" ]; then
+  elif [ -n "$appupdate" ] || [ -n "$modupdate" ] || [ -n "$bgupdate" ]; then
     if false && [ -f "$arkserverroot/version.txt" ]; then
       arkversion="$(<"$arkserverroot/version.txt")"
     else
@@ -2157,7 +2157,7 @@ doUpdate() {
     fi
 
     if [ -n "$appupdate" ]; then
-      if [ -d "${arkStagingDir}" -a "${arkStagingDir}" != "${arkserverroot}" ]; then
+      if [ -d "${arkStagingDir}" ] && [ "${arkStagingDir}" != "${arkserverroot}" ]; then
         logprint "Applying update from staging directory"
         if [ "$(stat -c "%d" "$arkserverroot")" == "$(stat -c "%d" "$arkStagingDir")" ]; then
           if [ -n "$useRefLinks" ]; then
@@ -2560,7 +2560,7 @@ isModUpdateNeeded(){
     fi
 
     while read f; do
-      if [ \( ! -f "$moddestdir/${f%.z}" \) -o "$modsrcdir/$f" -nt "$moddestdir/${f%.z}" ]; then
+      if [ \( ! -f "$moddestdir/${f%.z}" \) ] || [ "$modsrcdir/$f" -nt "$moddestdir/${f%.z}" ]; then
         return 0
       fi
     done < <(find "$modsrcdir" -type f ! -name "*.z.uncompressed_size" -printf "%P\n")
@@ -2665,7 +2665,7 @@ doExtractMod(){
     find "$modsrcdir" -type d -printf "$modextractdir/%P\0" | xargs -0 -r mkdir -p
 
     find "$modextractdir" -type f ! -name '.*' -printf "%P\n" | while read f; do
-      if [ \( ! -f "$modsrcdir/$f" \) -a \( ! -f "$modsrcdir/${f}.z" \) ]; then
+      if [ \( ! -f "$modsrcdir/$f" \) ] && [ \( ! -f "$modsrcdir/${f}.z" \) ]; then
         rm "$modextractdir/$f"
       fi
     done
@@ -2677,7 +2677,7 @@ doExtractMod(){
     done
 
     find "$modsrcdir" -type f ! \( -name '*.z' -or -name '*.z.uncompressed_size' \) -printf "%P\n" | while read f; do
-      if [ \( ! -f "$modextractdir/$f" \) -o "$modsrcdir/$f" -nt "$modextractdir/$f" ]; then
+      if [ \( ! -f "$modextractdir/$f" \) ] || [ "$modsrcdir/$f" -nt "$modextractdir/$f" ]; then
         printf "%10d  %s  " "`stat -c '%s' "$modsrcdir/$f"`" "$f"
         if [[ -n "$useRefLinks" && "$(stat -c "%d" "$modsrcdir")" == "$(stat -c "%d" "$modextractdir")" ]]; then
           cp --reflink=auto "$modsrcdir/$f" "$modextractdir/$f"
@@ -2689,7 +2689,7 @@ doExtractMod(){
     done
 
     find "$modsrcdir" -type f -name '*.z' -printf "%P\n" | while read f; do
-      if [ \( ! -f "$modextractdir/${f%.z}" \) -o "$modsrcdir/$f" -nt "$modextractdir/${f%.z}" ]; then
+      if [ \( ! -f "$modextractdir/${f%.z}" \) ] || [ "$modsrcdir/$f" -nt "$modextractdir/${f%.z}" ]; then
         printf "%10d  %s  " "`stat -c '%s' "$modsrcdir/$f"`" "${f%.z}"
         perl -M'Compress::Raw::Zlib' -e '
           my $sig;

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1326,7 +1326,7 @@ doRun() {
 
     # Wait on the now-dead process to reap it and get its return status
     wait $serverpid
-    echo "`timestamp`: exited with status $?"
+    echo "$(timestamp): exited with status $?"
 
     # doStop will remove the autorestart file
     if [ ! -f "$arkserverroot/$arkautorestartfile" ]; then
@@ -1336,12 +1336,14 @@ doRun() {
 
     if [ "$restartserver" -ne 0 ]; then
       notify "${notifyMsgServerTerminated:-Server exited - restarting}"
-      echo "`timestamp`: restarting server"
+      echo "$(timestamp): restarting server"
     fi
   done
 }
 
 doRunBG(){
+  # Iterating over ls might be fragile, /proc/*/fs shouldn't be affected.
+  # shellcheck disable=SC2045
   for fd in $(ls /proc/$BASHPID/fd/); do
     [[ $fd -gt 2 && $fd != 255 ]] && exec {fd}<&-
   done

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -128,7 +128,7 @@ doUpgradeToolsFromBranch(){
   if [[ $arkstLatestVersion > $arkstVersion ]]; then
     read -p "A new version was found! Do you want to upgrade ARK Server Tools to v${arkstLatestVersion}?" -n 1 -r
     echo
-  elif [[ $arkstLatestVersion == $arkstVersion && "$arkstLatestCommit" != "$arkstCommit" ]]; then
+  elif [[ $arkstLatestVersion == "$arkstVersion" && "$arkstLatestCommit" != "$arkstCommit" ]]; then
     read -p "A hotfix is available for v${arkstLatestVersion}.  Do you wish to install it?" -n 1 -r
     echo
   else
@@ -939,7 +939,7 @@ function getServerPID(){
 # Check id the server process is alive
 #
 function isTheServerRunning(){
-  if [ -n "`getServerPID`" ]; then
+  if [ -n "$(getServerPID)" ]; then
     return 0
   else
     return 1
@@ -2882,7 +2882,7 @@ doEnableMod(){
 doDisableMod(){
   local modid="$1"
   local modvar="arkmod_$modid"
-  if [ "$ark_GameModIds" = *"$modid"* ]; then
+  if [[ "$ark_GameModIds" = *"$modid"* ]]; then
     sed -i "s|^\(ark_GameModIds=\(\|[\"']\)\(\|[^\"' ]*,\)\)${modid},*|\1|" "$configfile"
   fi
   if [ -n "$modvar" ]; then

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -2944,7 +2944,7 @@ doBackup(){
     return 1
   fi
 
-  echo "${NORMAL} Saved arks directory is ${savedir}"
+  echo -e "${NORMAL} Saved arks directory is ${savedir}"
 
   # ARK server uses Write-Unlink-Rename
   echo -ne "${NORMAL} Copying ARK world file (${mapname}) "

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -111,8 +111,8 @@ doUpgradeToolsFromCommit(){
 }
 
 doUpgradeToolsFromBranch(){
-  arkstLatestVersion=`curl -s "https://raw.githubusercontent.com/${arkstGithubRepo}/${arkstChannel}/.version"`
-  arkstLatestCommit=`curl -s "https://api.github.com/repos/${arkstGithubRepo}/git/refs/heads/${arkstChannel}" | sed -n 's/^ *"sha": "\(.*\)",.*/\1/p'`
+  arkstLatestVersion=$(curl -s "https://raw.githubusercontent.com/${arkstGithubRepo}/${arkstChannel}/.version")
+  arkstLatestCommit=$(curl -s "https://api.github.com/repos/${arkstGithubRepo}/git/refs/heads/${arkstChannel}" | sed -n 's/^ *"sha": "\(.*\)",.*/\1/p')
 
   if [[ "$arkstLatestVersion" == "404: Not Found" ]]; then
     echo "Channel '${arkstChannel}' does not exist"
@@ -1516,7 +1516,7 @@ doStop() {
     rm -f "$arkserverroot/$arkautorestartfile"
     rm -f "$arkserverroot/$arkoldautorestartfile"
     # kill the server with the PID
-    PID=`getServerPID`
+    PID=$(getServerPID)
     kill -INT $PID >/dev/null 2>&1
 
     for (( i = 0; i < 20; i++ )); do
@@ -1802,7 +1802,7 @@ doWarn(){
     trap "update_cancelled 'Connection Closed'" SIGHUP
     trap "update_cancelled 'Quit'" SIGQUIT
 
-    local pid=`getServerPID`
+    local pid=$(getServerPID)
     local sleeppid
     local usenotify=1
     if [ -n "$noNotifyWarn" ]; then
@@ -2915,8 +2915,8 @@ doRemoveMods(){
 # Copies server state to a backup directory
 #
 doBackup(){
-  local datestamp=`date +"%Y-%m-%d_%H.%M.%S"`
-  local daystamp=`date +"%Y-%m-%d"`
+  local datestamp=$(date +"%Y-%m-%d_%H.%M.%S")
+  local daystamp=$(date +"%Y-%m-%d")
   local backupdir="${arkbackupdir}/${datestamp}"
   local backupdirdaily="${arkbackupdir}/${daystamp}"
   local saverootdir="${arkserverroot}/${arkserverdir}/Saved"

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -49,7 +49,7 @@ doUpgradeTools() {
     echo "arkmanager v${arkstVersion}: Please check for, and install, updates using your system's package manager"
   else
     local sudo=sudo
-    if [ $(id -u) == 0 -o "$steamcmd_user" == "--me" ]; then
+    if [ "$(id -u)" == 0 ] || [ "$steamcmd_user" == "--me" ]; then
       sudo=
     fi
 
@@ -76,7 +76,7 @@ doUpgradeTools() {
 
 doUpgradeToolsFromCommit(){
   local sudo=sudo
-  if [ $(id -u) == 0 -o "$steamcmd_user" == "--me" ]; then
+  if [ "$(id -u)" == 0 ] || [ "$steamcmd_user" == "--me" ]; then
     sudo=
   fi
 
@@ -177,7 +177,7 @@ doUninstallTools() {
     echo "arkmanager v${arkstVersion}: Please uninstall using your system's package manager"
   else
     local sudo=sudo
-    if [ $(id -u) == 0 -o "$steamcmd_user" == "--me" ]; then
+    if [ "$(id -u)" == 0 ] || [ "$steamcmd_user" == "--me" ]; then
       sudo=
     fi
 

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1,5 +1,5 @@
 #!/bin/bash
-# shellcheck disable=SC2155
+# shellcheck disable=SC2154,SC2155 source=arkmanager.cfg,instance.cfg.example
 
 # ARK: survival evolved manager
 #

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2155
 
 # ARK: survival evolved manager
 #
@@ -1748,6 +1749,8 @@ isUpdateCancelRequested(){
         xargs -0 grep -F -e "${chatCommandRestartCancel}" | 
         sed 's@^[[]\(....\)\.\(..\)\.\(..\)-\(..\)\.\(..\)\.\(..\):.*@\1-\2-\3 \4:\5:\6 UTC@' | 
         head -n1)"
+    # canceltime is a command, not a string
+    # shellcheck disable=SC2157
     if [ -n canceltime ]; then
       canceltime="$(date +%s --date="${canceltime}")"
       local timenow="$(date +%s --date="now - 5 minutes")"
@@ -3155,8 +3158,8 @@ doRestore(){
     if [[ -f "$arkbackupdir/$backupFile" ]] ; then
       backupFile="$arkbackupdir/$backupFile"
     else
-      echo "File $backupFile not found."
-      exit -1
+      echo "File $backupFile not found." 1>&2
+      exit 1
     fi
   fi
   echo "Restoring from ${backupFile}"


### PR DESCRIPTION
In an effort to make the `arkmanager` more robust, I've let it lint by [shellcheck](https://github.com/koalaman/shellcheck), got rid of all "errors" and implemented some of their hints in different warnings.

On top of that, I've set up a Github action that runs shellcheck on every push. It'll be nagging a lot, since I've configured the "error" threshold as "warning" (see f5312ee), but I'll go ahead and change more things.