### PR TITLE
Update invalid steam query port number on README.md

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -79,8 +79,8 @@ Requirements
 To allow your ARK server to communicate with the outside you have to open some ports in your firewall:
 
 ```sh
-iptables -I INPUT -p udp --dport 27016 -j ACCEPT
-iptables -I INPUT -p tcp --dport 27016 -j ACCEPT
+iptables -I INPUT -p udp --dport 27015 -j ACCEPT
+iptables -I INPUT -p tcp --dport 27015 -j ACCEPT
 iptables -I INPUT -p udp --dport 7777 -j ACCEPT
 iptables -I INPUT -p tcp --dport 7777 -j ACCEPT
 iptables -I INPUT -p udp --dport 7778 -j ACCEPT


### PR DESCRIPTION
Using 27016 is invalid by default. Using 27015 in basic instructions should be better.