### PR TITLE
Fixed switching the --beta

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -2207,6 +2207,9 @@ doUpdate() {
 
   cd "$arkserverroot"
 
+  # If a beta was requested via --beta, ensure version checks use that branch
+  appbranch="${appbeta:-public}"
+
   if [ -n "$appupdate" ] || isUpdateNeeded; then
     appupdate=1
 


### PR DESCRIPTION
Fixed a bug where the update would not occur even if preaquatica and public were specified alternately with the --beta option.
